### PR TITLE
Allow aborting a .save in before_save

### DIFF
--- a/data_migration/migration.py
+++ b/data_migration/migration.py
@@ -118,6 +118,10 @@ class Migration(object):
         """Is called right before the migrated instance is saved.
 
         Do the changes, that make the instance valid, in this hook.
+        
+        If the instance should not be committed, e.g. due to a runtime check
+        failing, you may return False which will prevent the model's save
+        method and after_save hooks from being called.
 
         :param instance: the migrating instance which could be altered
         :param row: the dict which represents one row of the SQL query

--- a/data_migration/migration.py
+++ b/data_migration/migration.py
@@ -303,7 +303,10 @@ class Migration(object):
             constructor_data, m2ms = self.transform_row_dataset(row)
             instance = self.model(**constructor_data)
 
-            self.hook_before_save(instance, row)
+            before_save_success = self.hook_before_save(instance, row)
+            if before_save_success == False:
+                sys.stdout.write("Skipping: before_save returned False")
+                return
 
             instance.save()
             self.create_m2ms(instance, m2ms)


### PR DESCRIPTION
Sometimes you may be aware there's a problem with a record in before_save, but you still want to push ahead with the migration. You can't simply catch the exception as the error will disrupt the database transaction and prevent everything from being committed. This allows before_save hooks to return False. Otherwise achieved by setting <code>instance.save = lambda : None</code>.
