### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,13 +66,13 @@ Start participating
 -  Run the tests with ``tox`` against all supported versions of Python
 -  Create a Pull Request on Github
 
-.. |PyPi version| image:: https://pypip.in/v/django-data-migration/badge.png
+.. |PyPi version| image:: https://img.shields.io/pypi/v/django-data-migration.svg
    :target: https://crate.io/packages/django-data-migration/
-.. |PyPi downloads| image:: https://pypip.in/d/django-data-migration/badge.png
+.. |PyPi downloads| image:: https://img.shields.io/pypi/dm/django-data-migration.svg
    :target: https://crate.io/packages/django-data-migration/
 .. |Build Status| image:: https://travis-ci.org/pboehm/django-data-migration.png?branch=master
    :target: https://travis-ci.org/pboehm/django-data-migration
-.. |License| image:: https://pypip.in/license/django-data-migration/badge.png
+.. |License| image:: https://img.shields.io/pypi/l/django-data-migration.svg
    :target: https://pypi.python.org/pypi/django-data-migration/
 .. |Coverage| image:: https://coveralls.io/repos/pboehm/django-data-migration/badge.png?branch=master
    :target: https://coveralls.io/r/pboehm/django-data-migration?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-data-migration))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-data-migration`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.